### PR TITLE
Use Leaflet utils to get wheel delta from event

### DIFF
--- a/SmoothWheelZoom.js
+++ b/SmoothWheelZoom.js
@@ -54,7 +54,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
     _onWheeling: function (e) {
         var map = this._map;
 
-        this._goalZoom = this._goalZoom - e.deltaY * 0.003 * map.options.smoothSensitivity;
+        this._goalZoom = this._goalZoom + L.DomEvent.getWheelDelta(e) * 0.003 * map.options.smoothSensitivity;
         if (this._goalZoom < map.getMinZoom() || this._goalZoom > map.getMaxZoom()) {
             this._goalZoom = map._limitZoom(this._goalZoom);
         }


### PR DESCRIPTION
Zooming is a lot slower on Firefox at the moment. This PR uses Leaflet DomEvent util to get the wheel delta (Leaflet ScrollWheelZoom handler uses the same method, so it's probably well tested and should work cross browser).