### PR TITLE
Fix for leaflet 1.7.1

### DIFF
--- a/SmoothWheelZoom.js
+++ b/SmoothWheelZoom.js
@@ -16,11 +16,11 @@ L.Map.mergeOptions({
 L.Map.SmoothWheelZoom = L.Handler.extend({
 
     addHooks: function () {
-        L.DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
+        L.DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
     },
 
     removeHooks: function () {
-        L.DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll, this);
+        L.DomEvent.off(this._map._container, 'wheel', this._onWheelScroll, this);
     },
 
     _onWheelScroll: function (e) {


### PR DESCRIPTION
The plugin is broken for leaflet 1.7.1 when using Firefox. Trying to zoom by wheeling does nothing.

This is the specific commit in Leaflet that broke it: 

https://github.com/Leaflet/Leaflet/commit/9be733ee38073d7e66d26a606927f700a0374957

You can see that they changed the event named `mousewheel` to `wheel`. The default scrollWheelZoom uses `wheel` now instead of `mousewheel` (that changed also in the same commit).