### PR TITLE
Fix the map position jumping if the mouse moves while scrolling

### DIFF
--- a/SmoothWheelZoom.js
+++ b/SmoothWheelZoom.js
@@ -36,7 +36,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
         this._wheelMousePosition = map.mouseEventToContainerPoint(e);
         this._centerPoint = map.getSize()._divideBy(2);
         this._startLatLng = map.containerPointToLatLng(this._centerPoint);
-        this._wheelStartLatLng = map.containerPointToLatLng(this._wheelMousePosition);
+        this._wheelMouseLatLng = map.containerPointToLatLng(this._wheelMousePosition);
         this._startZoom = map.getZoom();
         this._moved = false;
         this._zooming = true;
@@ -59,6 +59,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
             this._goalZoom = map._limitZoom(this._goalZoom);
         }
         this._wheelMousePosition = this._map.mouseEventToContainerPoint(e);
+        this._wheelMouseLatLng = map.containerPointToLatLng(this._wheelMousePosition);
 
         clearTimeout(this._timeoutId);
         this._timeoutId = setTimeout(this._onWheelEnd.bind(this), 200);
@@ -89,7 +90,7 @@ L.Map.SmoothWheelZoom = L.Handler.extend({
         if (map.options.smoothWheelZoom === 'center') {
             this._center = this._startLatLng;
         } else {
-            this._center = map.unproject(map.project(this._wheelStartLatLng, this._zoom).subtract(delta), this._zoom);
+            this._center = map.unproject(map.project(this._wheelMouseLatLng, this._zoom).subtract(delta), this._zoom);
         }
 
         if (!this._moved) {


### PR DESCRIPTION
If the mouse moves at all while scrolling, the map pans with the mouse movement in a very janky way, as shows in this video:

https://user-images.githubusercontent.com/3784591/201303563-7ab133c3-1969-4476-8187-850ce9b49482.mp4

This seems to fix it!