### PR TITLE
suggest disabling zoom snapping in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ var map = L.map('map', {
   scrollWheelZoom: false, // disable original zoom function
   smoothWheelZoom: true,  // enable smooth zoom 
   smoothSensitivity: 1,   // zoom speed. default is 1
+  zoomSnap: 0,            // disable zoom snapping (for touchscreen zooming, and fitBounds(), etc.)
 });
 ```
 


### PR DESCRIPTION
This plugin effectively bypassing zoom snapping when scrolling with the mouse, but anything else that changes the zoom -- pinch zooming with a touch screen, or calling `fitBounds()` -- causes the zoom to snap again.